### PR TITLE
Fix issue with JSON request payload not being parsed

### DIFF
--- a/server/src/routes/user.ts
+++ b/server/src/routes/user.ts
@@ -6,6 +6,9 @@ const router = express.Router();
 import { IUser, UserModel } from "../models/user";
 import { UserErrors } from "../common/errors";
 
+// (for HTTP Request testing only)
+router.use(express.json());
+
 router.post("/register", async (req, res) => {
   const { username, password } = req.body;
   try {


### PR DESCRIPTION
The commit introduces the use of the `express.json()` middleware to address a problem where incoming HTTP requests with a JSON payload were not being properly parsed. This middleware instructs Express to handle JSON payloads and populate the `req.body` object with the parsed JSON data.

Note: This change is intended to resolve issues encountered during testing HTTP requests. As a newcomer to open source, the commit is aimed at improving the functionality without introducing risks to the production environment.